### PR TITLE
feat(messaging): implement chequera message deduplication system #48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.0-jre</version>
+            <version>33.4.5-jre</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/java/um/tesoreria/sender/client/tesoreria/core/ChequeraMessageCheckClient.java
+++ b/src/main/java/um/tesoreria/sender/client/tesoreria/core/ChequeraMessageCheckClient.java
@@ -1,0 +1,21 @@
+package um.tesoreria.sender.client.tesoreria.core;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import um.tesoreria.sender.kotlin.dto.tesoreria.core.ChequeraMessageCheckDto;
+
+import java.util.UUID;
+
+@FeignClient(name = "tesoreria-core-service/api/tesoreria/core/chequeraMessageCheck")
+public interface ChequeraMessageCheckClient {
+
+    @GetMapping("/{chequeraMessageCheckId}")
+    ChequeraMessageCheckDto findByChequeraMessageCheckId(@PathVariable UUID chequeraMessageCheckId);
+
+    @PostMapping("/")
+    ChequeraMessageCheckDto add(@RequestBody ChequeraMessageCheckDto chequeraMessageCheck);
+
+}

--- a/src/main/java/um/tesoreria/sender/consumer/ChequeraConsumer.java
+++ b/src/main/java/um/tesoreria/sender/consumer/ChequeraConsumer.java
@@ -2,24 +2,33 @@ package um.tesoreria.sender.consumer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.rabbitmq.client.Channel;
 import jakarta.annotation.PostConstruct;
-import jakarta.mail.MessagingException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import um.tesoreria.sender.client.tesoreria.core.ChequeraMessageCheckClient;
 import um.tesoreria.sender.configuration.RabbitMQConfig;
+import um.tesoreria.sender.kotlin.dto.tesoreria.core.ChequeraMessageCheckDto;
 import um.tesoreria.sender.kotlin.dto.tesoreria.core.message.ChequeraMessageDto;
 import um.tesoreria.sender.service.ChequeraService;
+
+import java.io.IOException;
+import java.util.UUID;
 
 @Component
 @Slf4j
 public class ChequeraConsumer {
 
     private final ChequeraService chequeraService;
+    private final ChequeraMessageCheckClient chequeraMessageCheckClient;
 
-    public ChequeraConsumer(ChequeraService chequeraService) {
+    public ChequeraConsumer(ChequeraService chequeraService, ChequeraMessageCheckClient chequeraMessageCheckClient) {
         this.chequeraService = chequeraService;
+        this.chequeraMessageCheckClient = chequeraMessageCheckClient;
     }
 
     @PostConstruct
@@ -28,30 +37,76 @@ public class ChequeraConsumer {
         log.error("TEST - PostConstruct ChequeraConsumer ejecutado");
     }
 
-    @RabbitListener(queues = RabbitMQConfig.QUEUE_CHEQUERA)
+    @RabbitListener(queues = RabbitMQConfig.QUEUE_CHEQUERA, ackMode = "MANUAL")
     @Transactional
-    public void handleChequeraMessage(ChequeraMessageDto chequeraMessage) throws MessagingException {
-        log.info("Processing chequera shipment");
+    public void handleChequeraMessage(ChequeraMessageDto chequeraMessage, Channel channel, @Header(AmqpHeaders.DELIVERY_TAG) long tag) throws IOException {
+        log.info("Processing ChequeraConsumer.handleChequeraMessage");
         logChequeraMessage(chequeraMessage);
-        log.info(chequeraService.sendChequera(chequeraMessage.getFacultadId(),
-                                              chequeraMessage.getTipoChequeraId(),
-                                              chequeraMessage.getChequeraSerieId(),
-                                              chequeraMessage.getAlternativaId(),
-                                              chequeraMessage.getCopiaInformes(),
-                                              chequeraMessage.getCodigoBarras(),
-                                              chequeraMessage.getIncluyeMatricula()));
+        
+        try {
+            log.debug("handleChequeraMessage - buscando si ya fue enviado");
+            boolean sentMessage = verifySentMessage(chequeraMessage.getUuid());
+            
+            if (sentMessage) {
+                log.info("handleChequeraMessage - mensaje ya fue enviado previamente, UUID: {}", chequeraMessage.getUuid());
+                channel.basicAck(tag, false);
+                return;
+            }
+            
+            String result = chequeraService.sendChequera(
+                chequeraMessage.getFacultadId(),
+                chequeraMessage.getTipoChequeraId(),
+                chequeraMessage.getChequeraSerieId(),
+                chequeraMessage.getAlternativaId(),
+                chequeraMessage.getCopiaInformes(),
+                chequeraMessage.getCodigoBarras(),
+                chequeraMessage.getIncluyeMatricula()
+            );
+            
+            log.info("handleChequeraMessage - resultado del envío: {}", result);
+            channel.basicAck(tag, false);
+            log.debug("handleChequeraMessage - guardando chequeraMessageCheck");
+            var chequeraMessageCheck = new ChequeraMessageCheckDto.Builder()
+                    .chequeraMessageCheckId(chequeraMessage.getUuid())
+                    .facultadId(chequeraMessage.getFacultadId())
+                    .tipoChequeraId(chequeraMessage.getTipoChequeraId())
+                    .chequeraSerieId(chequeraMessage.getChequeraSerieId())
+                    .payload(jsonChequeraMessage(chequeraMessage))
+                    .build();
+
+            chequeraMessageCheckClient.add(chequeraMessageCheck);
+
+        } catch (Exception e) {
+            log.error("handleChequeraMessage - error al procesar mensaje, UUID: {}, error: {}", 
+                chequeraMessage.getUuid(), e.getMessage(), e);
+            channel.basicNack(tag, false, true);
+        }
+    }
+
+    private boolean verifySentMessage(UUID uuid) {
+        try {
+            chequeraMessageCheckClient.findByChequeraMessageCheckId(uuid);
+            return true;
+        } catch (Exception e) {
+            log.debug("verifySentMessage - mensaje no encontrado, UUID: {}", uuid);
+            return false;
+        }
     }
 
     private void logChequeraMessage(ChequeraMessageDto chequeraMessage) {
+        log.debug("ChequeraMessage -> {}", jsonChequeraMessage(chequeraMessage));
+    }
+
+    private String jsonChequeraMessage(ChequeraMessageDto chequeraMessage) {
         try {
-            log.debug("ChequeraMessage -> {}", JsonMapper
+            return JsonMapper
                     .builder()
                     .findAndAddModules()
                     .build()
                     .writerWithDefaultPrettyPrinter()
-                    .writeValueAsString(chequeraMessage));
+                    .writeValueAsString(chequeraMessage);
         } catch (JsonProcessingException e) {
-            log.debug("ChequeraMessage jsonify error: {}", e.getMessage());
+            return "ChequeraMessage jsonify error";
         }
     }
 

--- a/src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/ChequeraMessageCheckDto.kt
+++ b/src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/ChequeraMessageCheckDto.kt
@@ -1,0 +1,51 @@
+package um.tesoreria.sender.kotlin.dto.tesoreria.core
+
+import java.util.*
+
+data class ChequeraMessageCheckDto (
+    var chequeraMessageCheckId: UUID? = null,
+    var facultadId: Integer? = null,
+    var tipoChequeraId: Integer? = null,
+    var chequeraSerieId: Long? = null,
+    var payload: String = ""
+) {
+    class Builder {
+        private var chequeraMessageCheckId: UUID? = null
+        private var facultadId: Integer? = null
+        private var tipoChequeraId: Integer? = null
+        private var chequeraSerieId: Long? = null
+        private var payload: String = ""
+
+        fun chequeraMessageCheckId(chequeraMessageCheckId: UUID?) = apply { 
+            this.chequeraMessageCheckId = chequeraMessageCheckId 
+        }
+
+        fun facultadId(facultadId: Integer?) = apply {
+            this.facultadId = facultadId
+        }
+
+        fun tipoChequeraId(tipoChequeraId: Integer?) = apply {
+            this.tipoChequeraId = tipoChequeraId
+        }
+
+        fun chequeraSerieId(chequeraSerieId: Long?) = apply {
+            this.chequeraSerieId = chequeraSerieId
+        }
+
+        fun payload(payload: String) = apply {
+            this.payload = payload 
+        }
+
+        fun build() = ChequeraMessageCheckDto(
+            chequeraMessageCheckId = chequeraMessageCheckId,
+            facultadId = facultadId,
+            tipoChequeraId = tipoChequeraId,
+            chequeraSerieId = chequeraSerieId,
+            payload = payload
+        )
+    }
+
+    companion object {
+        fun builder() = Builder()
+    }
+}

--- a/src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/message/ChequeraMessageDto.kt
+++ b/src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/message/ChequeraMessageDto.kt
@@ -1,7 +1,10 @@
 package um.tesoreria.sender.kotlin.dto.tesoreria.core.message
 
+import java.util.UUID
+
 data class ChequeraMessageDto(
 
+    var uuid: UUID,
     var facultadId: Int,
     var tipoChequeraId: Int,
     var chequeraSerieId: Long,


### PR DESCRIPTION
- Add ChequeraMessageCheckClient for message tracking and verification
- Create ChequeraMessageCheckDto with Builder pattern for message storage
- Add UUID field to ChequeraMessageDto for unique message identification
- Enhance ChequeraConsumer with manual acknowledgment and deduplication logic
- Update Guava dependency to version 33.4.5-jre

BREAKING CHANGE: ChequeraMessageDto now requires UUID field for message tracking

Co-authored-by: [Your Name] <your.email@um.edu.uy>
Closes #48