### PR TITLE
feat(email): implement email validation before sending receipts - Add…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UUID-based message tracking in DTOs
 - Manual acknowledgment mode for RabbitMQ consumers
 - Enhanced logging for message processing
+- New `ToolClient` for email validation
+- New `Tool` utility class for string to list conversion
+- Email validation before sending receipts
 
 ### Changed
 - Actualizado Spring Boot a versión 3.4.4
@@ -28,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Optimizado el consumo de memoria en el procesamiento de mensajes
 - Improved error handling in message consumers
 - Enhanced email address handling with testing mode
+- Modified email sending logic to validate addresses before sending
+- Added validation for personal, institutional and chequera emails
 
 ### Removed
 - Eliminado RabbitMQConfig.java

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Servicio de envío de correos electrónicos y notificaciones para UM Tesorería.
 - Sistema de deduplicación de mensajes con UUID tracking
 - Soporte para múltiples colas (recibo_queue, chequera_queue)
 - Generación automática de documentación y wiki
+- Validación de direcciones de email antes del envío
+- Manejo de casos donde no hay emails válidos para enviar
 
 ## Tecnologías
 

--- a/src/main/java/um/tesoreria/sender/client/tesoreria/core/facade/ToolClient.java
+++ b/src/main/java/um/tesoreria/sender/client/tesoreria/core/facade/ToolClient.java
@@ -1,0 +1,15 @@
+package um.tesoreria.sender.client.tesoreria.core.facade;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+
+@FeignClient(name = "tesoreria-core-service/api/tesoreria/core/tool")
+public interface ToolClient {
+
+    @PostMapping("/mailvalidate")
+    Boolean mailValidate(@RequestBody List<String> mailes);
+
+}

--- a/src/main/java/um/tesoreria/sender/service/util/Tool.java
+++ b/src/main/java/um/tesoreria/sender/service/util/Tool.java
@@ -1,0 +1,12 @@
+package um.tesoreria.sender.service.util;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Tool {
+
+    public static List<String> convertStringToList(String string) {
+        return Collections.singletonList(string);
+    }
+
+}


### PR DESCRIPTION
… ToolClient for email validation - Add Tool utility class for string to list conversion - Modify ReciboService to validate emails before sending - Add validation for personal, institutional and chequera emails - Add handling for cases with no valid emails Closes #60