### PR TITLE
chore(deps): actualizar dependencias y liberar v1.5.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,10 +18,10 @@ jobs:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
-      - name: Set up JDK 24
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.5.0] - 2026-02-04
+
+### Changed
+- Actualizado Spring Boot a versión 4.0.2 (desde 3.5.8) ([pom.xml])
+- Actualizado Java a versión 25 (desde 24) ([pom.xml], [.github/workflows/maven.yml], [Dockerfile])
+- Actualizado Kotlin a versión 2.3.0 (desde 2.2.21) ([pom.xml])
+- Actualizado Spring Cloud a versión 2025.1.0 (desde 2025.0.0) ([pom.xml])
+- Actualizado Springdoc OpenAPI a versión 3.0.1 (desde 2.8.10) ([pom.xml])
+- Actualizado Guava a versión 33.5.0-jre (desde 33.4.8-jre) ([pom.xml])
+- Actualizado ZXing Core a versión 3.5.4 (desde 3.5.3) ([pom.xml])
+- Actualizado Commons Lang3 a versión 3.20.0 (desde 3.18.0) ([pom.xml])
+- Mejorada configuración de Jackson ObjectMapper en SenderConfiguration para registar módulos automáticamente ([src/main/java/um/tesoreria/sender/configuration/SenderConfiguration.java])
+- Corregido tipo de datos en ChequeraMessageCheckDto: cambiado de Integer a Int para mejor compatibilidad Kotlin ([src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/ChequeraMessageCheckDto.kt])
+
 ## [1.4.0] - 2025-12-14
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Etapa 1: Compilación con Maven y JDK
 # Usamos una imagen oficial que contiene Maven y Java (Temurin)
-FROM maven:3-eclipse-temurin-24-alpine AS build
+FROM maven:3-eclipse-temurin-25-alpine AS build
 
 # Establecemos el directorio de trabajo
 WORKDIR /app
@@ -19,7 +19,7 @@ RUN mvn clean package
 
 # Etapa 2: Creación de la imagen final y ligera
 # Usamos una imagen solo con el JRE, que es más pequeña
-FROM eclipse-temurin:24-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 
 # Creamos un usuario y grupo no privilegiados por seguridad
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # UM.tesoreria.sender-service
 
-[![Java](https://img.shields.io/badge/Java-24-red.svg)](https://www.java.com/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-3.5.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
-[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.0.0-blue.svg)](https://spring.io/projects/spring-cloud)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.2.21-purple.svg)](https://kotlinlang.org/)
-[![OpenAPI](https://img.shields.io/badge/OpenAPI-2.8.10-lightblue.svg)](https://www.openapis.org/)
-[![Guava](https://img.shields.io/badge/Guava-33.4.8--jre-orange.svg)](https://github.com/google/guava)
+[![Java](https://img.shields.io/badge/Java-25-red.svg)](https://www.java.com/)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-purple.svg)](https://kotlinlang.org/)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-lightblue.svg)](https://www.openapis.org/)
+[![Guava](https://img.shields.io/badge/Guava-33.5.0--jre-orange.svg)](https://github.com/google/guava)
 [![OpenPDF](https://img.shields.io/badge/OpenPDF-3.0.0-yellow.svg)](https://github.com/LibrePDF/OpenPDF)
-[![Version](https://img.shields.io/badge/Version-1.4.0-success.svg)](https://github.com/UM-services/UM.tesoreria.sender-service/releases)
+[![Version](https://img.shields.io/badge/Version-1.5.0-success.svg)](https://github.com/UM-services/UM.tesoreria.sender-service/releases)
 
 Servicio encargado del envío de recibos y formularios de pago para la Tesorería de la Universidad de Mendoza.
 
@@ -28,7 +28,7 @@ Servicio encargado del envío de recibos y formularios de pago para la Tesorerí
 
 ## Requisitos
 
-- Java 24
+- Java 25
 - Maven 3.9+
 - Docker (opcional)
 
@@ -135,15 +135,15 @@ Servicio de envío de correos electrónicos y notificaciones para UM Tesorería.
 
 ## Tecnologías
 
-- Java 24
-- Spring Boot 3.5.6
-- Spring Cloud 2025.0.0
+- Java 25
+- Spring Boot 4.0.2
+- Spring Cloud 2025.1.0
 - Kafka
 - Spring Mail
 - Spring Cloud Netflix Eureka Client
-- OpenAPI (Springdoc) 2.8.10
-- Kotlin 2.2.21
-- Guava 33.4.8-jre
+- OpenAPI (Springdoc) 3.0.1
+- Kotlin 2.3.0
+- Guava 33.5.0-jre
 - OpenPDF 3.0.0
 
 ## Configuración

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.8</version>
+        <version>4.0.2</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>um.tesoreria</groupId>
     <artifactId>sender-service</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <name>UM.tesoreria.sender-service</name>
     <description>um.tesoreria.sender-service</description>
     <url/>
@@ -27,9 +27,9 @@
         <url/>
     </scm>
     <properties>
-        <java.version>24</java.version>
-        <kotlin.version>2.2.21</kotlin.version>
-        <spring-cloud.version>2025.0.0</spring-cloud.version>
+        <java.version>25</java.version>
+        <kotlin.version>2.3.0</kotlin.version>
+        <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.sender-service</sonar.projectKey>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.8.10</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>core</artifactId>
-            <version>3.5.3</version>
+            <version>3.5.4</version>
         </dependency>
         <dependency>
             <groupId>com.github.librepdf</groupId>
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>33.4.8-jre</version>
+            <version>33.5.0-jre</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -137,7 +137,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
+                <version>3.20.0</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>

--- a/src/main/java/um/tesoreria/sender/configuration/SenderConfiguration.java
+++ b/src/main/java/um/tesoreria/sender/configuration/SenderConfiguration.java
@@ -1,11 +1,18 @@
 package um.tesoreria.sender.configuration;
 
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableFeignClients(basePackages = "um.tesoreria.sender.client")
 @PropertySource("classpath:config/reports.properties")
 public class SenderConfiguration {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper().findAndRegisterModules();
+    }
 }

--- a/src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/ChequeraMessageCheckDto.kt
+++ b/src/main/java/um/tesoreria/sender/kotlin/dto/tesoreria/core/ChequeraMessageCheckDto.kt
@@ -6,8 +6,8 @@ import java.util.*
 data class ChequeraMessageCheckDto (
 
     var chequeraMessageCheckId: UUID? = null,
-    var facultadId: Integer? = null,
-    var tipoChequeraId: Integer? = null,
+    var facultadId: Int? = null,
+    var tipoChequeraId: Int? = null,
     var chequeraSerieId: Long? = null,
     var payload: String = ""
 
@@ -18,8 +18,8 @@ data class ChequeraMessageCheckDto (
 
     class Builder {
         private var chequeraMessageCheckId: UUID? = null
-        private var facultadId: Integer? = null
-        private var tipoChequeraId: Integer? = null
+        private var facultadId: Int? = null
+        private var tipoChequeraId: Int? = null
         private var chequeraSerieId: Long? = null
         private var payload: String = ""
 
@@ -27,11 +27,11 @@ data class ChequeraMessageCheckDto (
             this.chequeraMessageCheckId = chequeraMessageCheckId 
         }
 
-        fun facultadId(facultadId: Integer?) = apply {
+        fun facultadId(facultadId: Int?) = apply {
             this.facultadId = facultadId
         }
 
-        fun tipoChequeraId(tipoChequeraId: Integer?) = apply {
+        fun tipoChequeraId(tipoChequeraId: Int?) = apply {
             this.tipoChequeraId = tipoChequeraId
         }
 


### PR DESCRIPTION
Closes #93

## Descripción
Actualizaciones de dependencias clave y mejoras en la configuración del servicio para la release v1.5.0.

## Cambios Realizados
- Actualizado Java de 24 a 25
- Actualizado Spring Boot de 3.5.8 a 4.0.2
- Actualizado Spring Cloud de 2025.0.0 a 2025.1.0
- Actualizado Kotlin de 2.2.21 a 2.3.0
- Actualizado Springdoc OpenAPI de 2.8.10 a 3.0.1
- Actualizado Guava de 33.4.8-jre a 33.5.0-jre
- Actualizado ZXing Core de 3.5.3 a 3.5.4
- Actualizado Commons Lang3 de 3.18.0 a 3.20.0
- Mejorada configuración de Jackson ObjectMapper para registrar módulos automáticamente
- Corregido tipo de datos en ChequeraMessageCheckDto (de Integer a Int) para mejor compatibilidad Kotlin
- Actualizada workflow de GitHub Actions para usar JDK 25
- Actualizado Dockerfile para usar JDK 25
- Actualizada documentación en README.md y CHANGELOG.md

## Verificación
- Compilación exitosa con Maven
- Pruebas unitarias pasando
- Despliegue en entorno de prueba funcionando
