### PR TITLE
chore(deps): actualizar dependencias a Spring Boot 4.0.5, Kotlin 2.3.20, JDK 25

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -18,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -247,7 +247,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 
@@ -264,4 +264,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -43,7 +43,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=UM-services_UM.tesoreria.sender-service
 
-  # --- Job 1: Build the standard JVM image ---
+    # --- Job 1: Build the standard JVM image ---
   build-image:
     # Only run on pushes to the main branch
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.8.0] - 2026-04-04
+
+### Changed
+- Actualizado Spring Boot a versión 4.0.5 (desde 4.0.2) ([pom.xml])
+- Actualizado Kotlin a versión 2.3.20 (desde 2.3.0) ([pom.xml])
+- Actualizado Springdoc OpenAPI a versión 3.0.2 (desde 3.0.1) ([pom.xml])
+- Actualizado OpenPDF a versión 3.0.3 (desde 3.0.1) ([pom.xml])
+- Actualizado GitHub Actions: checkout@v6, setup-java@v5, cache@v5, upload-pages-artifact@v4, deploy-pages@v5, docker/login-action@v4, docker/metadata-action@v6, docker/setup-buildx-action@v4, docker/build-push-action@v7 ([.github/workflows/])
+- Actualizado JDK a versión 25 (desde 24) ([.github/workflows/maven.yml], [.github/workflows/generate-docs.yml])
+
+### Added
+- Nueva dependencia commons-fileupload 1.6.0 ([pom.xml])
+
+### Fixed
+- Eliminado import no utilizado (HttpStatus) en ChequeraController.java ([src/main/java/um/tesoreria/sender/controller/ChequeraController.java])
+
 ## [1.7.0] - 2026-03-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # UM.tesoreria.sender-service
 
 [![Java](https://img.shields.io/badge/Java-25-red.svg)](https://www.java.com/)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.5-brightgreen.svg)](https://spring.io/projects/spring-boot)
 [![Spring Cloud](https://img.shields.io/badge/Spring%20Cloud-2025.1.0-blue.svg)](https://spring.io/projects/spring-cloud)
-[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.0-purple.svg)](https://kotlinlang.org/)
-[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.1-lightblue.svg)](https://www.openapis.org/)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-purple.svg)](https://kotlinlang.org/)
+[![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.2-lightblue.svg)](https://www.openapis.org/)
 [![Guava](https://img.shields.io/badge/Guava-33.5.0--jre-orange.svg)](https://github.com/google/guava)
-[![OpenPDF](https://img.shields.io/badge/OpenPDF-3.0.1-yellow.svg)](https://github.com/LibrePDF/OpenPDF)
-[![Version](https://img.shields.io/badge/Version-1.7.0-success.svg)](https://github.com/UM-services/UM.tesoreria.sender-service/releases)
+[![OpenPDF](https://img.shields.io/badge/OpenPDF-3.0.3-yellow.svg)](https://github.com/LibrePDF/OpenPDF)
+[![Version](https://img.shields.io/badge/Version-1.8.0-success.svg)](https://github.com/UM-services/UM.tesoreria.sender-service/releases)
 
 Servicio encargado del envío de recibos y formularios de pago para la Tesorería de la Universidad de Mendoza.
 
@@ -136,15 +136,15 @@ Servicio de envío de correos electrónicos y notificaciones para UM Tesorería.
 ## Tecnologías
 
 - Java 25
-- Spring Boot 4.0.2
+- Spring Boot 4.0.5
 - Spring Cloud 2025.1.0
 - Kafka
 - Spring Mail
 - Spring Cloud Netflix Eureka Client
-- OpenAPI (Springdoc) 3.0.1
-- Kotlin 2.3.0
+- OpenAPI (Springdoc) 3.0.2
+- Kotlin 2.3.20
 - Guava 33.5.0-jre
-- OpenPDF 3.0.1
+- OpenPDF 3.0.3
 
 ## Configuración
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.2</version>
+        <version>4.0.5</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>um.tesoreria</groupId>
     <artifactId>sender-service</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
     <name>UM.tesoreria.sender-service</name>
     <description>um.tesoreria.sender-service</description>
     <url/>
@@ -28,7 +28,7 @@
     </scm>
     <properties>
         <java.version>25</java.version>
-        <kotlin.version>2.3.0</kotlin.version>
+        <kotlin.version>2.3.20</kotlin.version>
         <spring-cloud.version>2025.1.0</spring-cloud.version>
         <sonar.organization>um-services</sonar.organization>
         <sonar.projectKey>UM-services_UM.tesoreria.sender-service</sonar.projectKey>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.1</version>
+            <version>3.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.github.openjson</groupId>
@@ -145,6 +145,11 @@
                 <version>${spring-cloud.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+                <version>1.6.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/java/um/tesoreria/sender/controller/ChequeraController.java
+++ b/src/main/java/um/tesoreria/sender/controller/ChequeraController.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;


### PR DESCRIPTION
Closes #99

## Descripción
Actualización de dependencias del proyecto a versiones más recientes y mejoras en los workflows de GitHub Actions.

## Cambios Realizados
- **pom.xml**: Actualizado Spring Boot 4.0.2 → 4.0.5, Kotlin 2.3.0 → 2.3.20, Springdoc OpenAPI 3.0.1 → 3.0.2, OpenPDF 3.0.1 → 3.0.3. Añadida nueva dependencia commons-fileupload 1.6.0. Versión del proyecto 1.7.0 → 1.8.0.
- **.github/workflows/generate-docs.yml**: Actualizado checkout@v4 → v6, setup-java@v4 → v5, JDK 24 → 25, upload-pages-artifact@v3 → v4, deploy-pages@v4 → v5.
- **.github/workflows/maven.yml**: Actualizado checkout@v4 → v6, setup-java@v4 → v5, cache@v4 → v5, docker/login-action@v3 → v4, docker/metadata-action@v5 → v6, docker/setup-buildx-action@v3 → v4, docker/build-push-action@v6 → v7, JDK 24 → 25.
- **CHANGELOG.md**: Añadidas entradas para versión 1.8.0.
- **README.md**: Actualizadas versiones en badges.
- **ChequeraController.java**: Eliminado import no utilizado (HttpStatus).

## Verificación
- Ejecución de `mvn clean verify` para verificar compilación y tests.
- Los workflows de GitHub Actions se ejecutarán automáticamente al crear el PR.
