### PR TITLE
feat(mail)!: split mail.from into chequera and recibo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.0.0] - 2026-06-09
+
+### Added
+- Nueva propiedad configurable `app.mail.fromrecibo` para definir el remitente en envíos de recibos ([src/main/java/um/tesoreria/sender/service/ReciboService.java], [src/main/resources/bootstrap.yml])
+- Validación null-safety con `Objects.requireNonNull()` en MercadoPagoService para evitar NullPointerException ([src/main/java/um/tesoreria/sender/service/MercadoPagoService.java])
+
+### Changed
+- Refactorizado MercadoPagoService usando `@RequiredArgsConstructor`, eliminando el constructor explícito ([src/main/java/um/tesoreria/sender/service/MercadoPagoService.java])
+- Reemplazado `addresses.toArray(new String[addresses.size()])` por `addresses.toArray(new String[0])` en MercadoPagoService ([src/main/java/um/tesoreria/sender/service/MercadoPagoService.java])
+- Actualizado diagrama de secuencia de envío de recibos con participantes detallados (ReciboController, FacturacionElectronicaClient, JavaMailSender, MimeMessageHelper, ReciboMessageCheckClient) y bloques activate/deactivate ([docs/diagrams/flujo-envio-recibo.mmd])
+
+### Removed
+- Eliminada propiedad `app.mail.from` — reemplazada por `app.mail.fromchequera` y `app.mail.fromrecibo` ([src/main/java/um/tesoreria/sender/service/ChequeraService.java], [src/main/resources/bootstrap.yml])
+
 ## [1.9.0] - 2026-06-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![OpenAPI](https://img.shields.io/badge/OpenAPI-3.0.2-lightblue.svg)](https://www.openapis.org/)
 [![Guava](https://img.shields.io/badge/Guava-33.5.0--jre-orange.svg)](https://github.com/google/guava)
 [![OpenPDF](https://img.shields.io/badge/OpenPDF-3.0.3-yellow.svg)](https://github.com/LibrePDF/OpenPDF)
-[![Version](https://img.shields.io/badge/Version-1.9.0-success.svg)](https://github.com/UM-services/UM.tesoreria.sender-service/releases)
+[![Version](https://img.shields.io/badge/Version-2.0.0-success.svg)](https://github.com/UM-services/UM.tesoreria.sender-service/releases)
 
 Servicio encargado del envío de recibos y formularios de pago para la Tesorería de la Universidad de Mendoza.
 
@@ -42,7 +42,8 @@ spring.application.name=um.tesoreria.sender-service
 server.port=8080
 
 # Configuración de email
-app.mail.from=${MAIL_FROM}
+app.mail.fromchequera=${MAIL_FROM_CHEQUERA}
+app.mail.fromrecibo=${MAIL_FROM_RECIBO}
 spring.mail.host=${MAIL_HOST}
 spring.mail.port=587
 spring.mail.username=${MAIL_USERNAME}
@@ -147,7 +148,7 @@ Este proyecto es privado y confidencial. Todos los derechos reservados.
 - Spring Cloud 2025.1.0
 - Kafka
 - Spring Mail
-- Spring Cloud Netflix Eureka Client
+- Spring Cloud Consul Discovery
 - OpenAPI (Springdoc) 3.0.2
 - Kotlin 2.3.20
 - Guava 33.5.0-jre

--- a/docs/diagrams/flujo-envio-recibo.mmd
+++ b/docs/diagrams/flujo-envio-recibo.mmd
@@ -1,20 +1,52 @@
 sequenceDiagram
     actor User
+    participant ReciboController
+    participant ReciboService
+    participant FacturacionElectronicaClient
+    participant JavaMailSender
+    participant MimeMessageHelper
+    participant ReciboMessageCheckClient
+
     User->>ReciboController: GET /api/tesoreria/sender/recibo/send/{id}
+    activate ReciboController
     ReciboController->>ReciboService: send(id, null)
+    activate ReciboService
+    
     ReciboService->>FacturacionElectronicaClient: findByFacturacionElectronicaId(id)
+    activate FacturacionElectronicaClient
     FacturacionElectronicaClient-->>ReciboService: facturacionElectronica
-    ReciboService->>ReciboService: generatePdf(...)
-    ReciboService-->>ReciboService: filenameRecibo
+    deactivate FacturacionElectronicaClient
+    
+    ReciboService->>ReciboService: generatePdf(id, facturacionElectronica, chequeraSerie)
+    Note over ReciboService: Genera archivo PDF del recibo
+    
     ReciboService->>JavaMailSender: createMimeMessage()
+    activate JavaMailSender
     JavaMailSender-->>ReciboService: message
+    deactivate JavaMailSender
+    
+    ReciboService->>MimeMessageHelper: MimeMessageHelper(message, true)
+    activate MimeMessageHelper
     ReciboService->>MimeMessageHelper: setTo(), setText(), setSubject(), addAttachment()
-    MimeMessageHelper-->>ReciboService: _
+    MimeMessageHelper-->>ReciboService: helper
+    deactivate MimeMessageHelper
+    
     ReciboService->>JavaMailSender: send(message)
-    JavaMailSender-->>ReciboService:
+    activate JavaMailSender
+    JavaMailSender-->>ReciboService: (void)
+    deactivate JavaMailSender
+    
     ReciboService->>FacturacionElectronicaClient: update(facturacionElectronica)
+    activate FacturacionElectronicaClient
     FacturacionElectronicaClient-->>ReciboService: facturacionElectronica
+    deactivate FacturacionElectronicaClient
+    
     ReciboService->>ReciboMessageCheckClient: add(reciboMessageCheck)
+    activate ReciboMessageCheckClient
     ReciboMessageCheckClient-->>ReciboService: reciboMessageCheck
+    deactivate ReciboMessageCheckClient
+    
     ReciboService-->>ReciboController: "Envío de Correo Ok!!!"
+    deactivate ReciboService
     ReciboController-->>User: HTTP 200 OK
+    deactivate ReciboController

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>um.tesoreria</groupId>
     <artifactId>sender-service</artifactId>
-    <version>1.9.0</version>
+    <version>2.0.0</version>
     <name>UM.tesoreria.sender-service</name>
     <description>um.tesoreria.sender-service</description>
     <url/>

--- a/src/main/java/um/tesoreria/sender/service/ChequeraService.java
+++ b/src/main/java/um/tesoreria/sender/service/ChequeraService.java
@@ -40,8 +40,8 @@ public class ChequeraService {
     @Value("${app.testing}")
     private Boolean testing;
 
-    @Value("${app.mail.from}")
-    private String mailFrom;
+    @Value("${app.mail.fromchequera}")
+    private String mailFromChequera;
 
     private final FormulariosToPdfService formulariosToPdfService;
     private final JavaMailSender javaMailSender;
@@ -259,7 +259,7 @@ public class ChequeraService {
         MimeMessage message = javaMailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(message, true);
 
-        helper.setFrom(mailFrom);
+        helper.setFrom(mailFromChequera);
         helper.setTo(recipients.toArray(new String[0]));
         helper.setSubject("Recordatorio - Pago cuota UM -> " + nombreAlumno);
         helper.setReplyTo("no-reply@um.edu.ar");

--- a/src/main/java/um/tesoreria/sender/service/MercadoPagoService.java
+++ b/src/main/java/um/tesoreria/sender/service/MercadoPagoService.java
@@ -2,6 +2,7 @@ package um.tesoreria.sender.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -12,36 +13,30 @@ import um.tesoreria.sender.kotlin.dto.tesoreria.core.DomicilioDto;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Service
+@RequiredArgsConstructor
 public class MercadoPagoService {
 
     private final ChequeraCuotaClient chequeraCuotaClient;
     private final MercadoPagoContextClient mercadoPagoContextClient;
     private final JavaMailSender javaMailSender;
 
-    public MercadoPagoService(ChequeraCuotaClient chequeraCuotaClient,
-                              MercadoPagoContextClient mercadoPagoContextClient,
-                              JavaMailSender javaMailSender) {
-        this.chequeraCuotaClient = chequeraCuotaClient;
-        this.mercadoPagoContextClient = mercadoPagoContextClient;
-        this.javaMailSender = javaMailSender;
-    }
-
     public String sendCuota(Long chequeraCuotaId) throws MessagingException {
         var chequeraCuota = chequeraCuotaClient.findByChequeraCuotaId(chequeraCuotaId);
         var mercadoPagoContext = mercadoPagoContextClient.findActivoByChequeraCuotaId(chequeraCuotaId);
 
-        DomicilioDto domicilio = chequeraCuota.getChequeraSerie().getDomicilio();
+        DomicilioDto domicilio = Objects.requireNonNull(chequeraCuota.getChequeraSerie()).getDomicilio();
         if (domicilio == null) {
             return "ERROR: Sin datos de e-mail para ENVIAR";
         }
-        if (domicilio.getEmailPersonal().isEmpty() && domicilio.getEmailInstitucional().isEmpty()) {
+        if (Objects.requireNonNull(domicilio.getEmailPersonal()).isEmpty() && Objects.requireNonNull(domicilio.getEmailInstitucional()).isEmpty()) {
             return "ERROR: Sin datos de e-mail para ENVIAR";
         }
 
         // Obtener el nombre del alumno
-        String nombreAlumno = chequeraCuota.getChequeraSerie().getPersona().getApellidoNombre();
+        String nombreAlumno = Objects.requireNonNull(chequeraCuota.getChequeraSerie().getPersona()).getApellidoNombre();
 
         // Formatear la fecha de vencimiento
         String fechaVencimientoFormatted = mercadoPagoContext.getFechaVencimiento()
@@ -81,15 +76,15 @@ public class MercadoPagoService {
                 "<p><strong>Estimad@ " + nombreAlumno + ",</strong></p>" +
                 "<p>Le compartimos los detalles:</p>" +
                 "<div class='info-section'>" +
-                "<p>Unidad Académica: <strong>" + chequeraCuota.getFacultad().getNombre() + "</strong></p>" +
+                "<p>Unidad Académica: <strong>" + Objects.requireNonNull(chequeraCuota.getFacultad()).getNombre() + "</strong></p>" +
                 "<br/>" +
-                "<p>Tipo de Chequera: <strong>" + chequeraCuota.getTipoChequera().getNombre() + "</strong></p>" +
+                "<p>Tipo de Chequera: <strong>" + Objects.requireNonNull(chequeraCuota.getTipoChequera()).getNombre() + "</strong></p>" +
                 "<br/>" +
-                "<p>Sede: <strong>" + chequeraCuota.getChequeraSerie().getGeografica().getNombre() + "</strong></p>" +
+                "<p>Sede: <strong>" + Objects.requireNonNull(chequeraCuota.getChequeraSerie().getGeografica()).getNombre() + "</strong></p>" +
                 "<br/>" +
-                "<p>Ciclo Lectivo: <strong>" + chequeraCuota.getChequeraSerie().getLectivo().getNombre() + "</strong></p>" +
+                "<p>Ciclo Lectivo: <strong>" + Objects.requireNonNull(chequeraCuota.getChequeraSerie().getLectivo()).getNombre() + "</strong></p>" +
                 "<br/>" +
-                "<p>Tipo de Arancel: <strong>" + chequeraCuota.getChequeraSerie().getArancelTipo().getDescripcion() + "</strong></p>" +
+                "<p>Tipo de Arancel: <strong>" + Objects.requireNonNull(chequeraCuota.getChequeraSerie().getArancelTipo()).getDescripcion() + "</strong></p>" +
                 "<br/>" +
                 "<p>Alternativa: <strong>" + chequeraCuota.getChequeraSerie().getAlternativaId() + "</strong></p>" +
                 "</div>" +
@@ -102,7 +97,7 @@ public class MercadoPagoService {
                 "<th>Enlace</th>" +
                 "</tr>" +
                 "<tr>" +
-                "<td>" + chequeraCuota.getProducto().getNombre() + "</td>" +
+                "<td>" + Objects.requireNonNull(chequeraCuota.getProducto()).getNombre() + "</td>" +
                 "<td>" + chequeraCuota.getMes() + "/" + chequeraCuota.getAnho() + "</td>" +
                 "<td>" + fechaVencimientoFormatted + "</td>" +
                 "<td>$" + String.format("%.2f", mercadoPagoContext.getImporte()) + "</td>" +
@@ -128,12 +123,12 @@ public class MercadoPagoService {
         if (!domicilio.getEmailPersonal().isEmpty()) {
             addresses.add(domicilio.getEmailPersonal());
         }
-        if (!domicilio.getEmailInstitucional().isEmpty()) {
+        if (!Objects.requireNonNull(domicilio.getEmailInstitucional()).isEmpty()) {
             addresses.add(domicilio.getEmailInstitucional());
         }
 
         try {
-            helper.setTo(addresses.toArray(new String[addresses.size()]));
+            helper.setTo(addresses.toArray(new String[0]));
             helper.setText(data, true);
             helper.setReplyTo("no-reply@um.edu.ar");
             helper.setSubject("Envío de Enlace de MercadoPago: " + nombreAlumno);

--- a/src/main/java/um/tesoreria/sender/service/ReciboService.java
+++ b/src/main/java/um/tesoreria/sender/service/ReciboService.java
@@ -54,6 +54,9 @@ public class ReciboService {
     @Value("${app.testing}")
     private Boolean testing;
 
+    @Value("${app.mail.fromrecibo}")
+    private String mailFromRecibo;
+
     private final Environment environment;
     private final FacturacionElectronicaClient facturacionElectronicaClient;
     private final JavaMailSender javaMailSender;
@@ -842,6 +845,7 @@ public class ReciboService {
 
         try {
             MimeMessageHelper helper = new MimeMessageHelper(message, true);
+            helper.setFrom(mailFromRecibo);
             helper.setTo(addresses.toArray(new String[0]));
             helper.setText(data);
             helper.setReplyTo("no-reply@um.edu.ar");

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -6,7 +6,8 @@ app:
     host: consul-service
     port: 8500
   mail:
-    from: from
+    fromchequera: fromchequera
+    fromrecibo: fromrecibo
     host: host
     username: uid
     password: pwd


### PR DESCRIPTION
Closes #103

## Descripción
Versión **2.0.0** del servicio con separación de la propiedad `app.mail.from` en dos configuraciones independientes (`fromchequera` y `fromrecibo`), refactor de null-safety en `MercadoPagoService`, actualización de documentación y correcciones menores.

## Cambios Realizados
- **`bootstrap.yml` / propiedades**: `app.mail.from` → `app.mail.fromchequera` + `app.mail.fromrecibo`
- **`ChequeraService.java`**: migrado de `mailFrom` a `mailFromChequera`
- **`ReciboService.java`**: agregado `mailFromRecibo` con `setFrom()` en la construcción del mensaje
- **`MercadoPagoService.java`**: null-safety con `Objects.requireNonNull()`, migración a `@RequiredArgsConstructor`, patrón optimizado `toArray(new String[0])`
- **`pom.xml`**: versión `1.9.0` → `2.0.0`
- **`CHANGELOG.md`**: nueva entrada v2.0.0
- **`README.md`**: badge de versión, sección de configuración de email, reemplazo Eureka → Consul
- **Diagrama de secuencia**: participantes detallados y bloques `activate`/`deactivate`

## Verificación
- [ ] Compilación con `mvn clean compile`
- [ ] Validar que las propiedades `MAIL_FROM_CHEQUERA` y `MAIL_FROM_RECIBO` estén definidas en los entornos
- [ ] Prueba de envío de recibo y chequera con los nuevos remitentes
