### PR TITLE
fix(test-config): align test bootstrap with new mail from properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reemplazado `addresses.toArray(new String[addresses.size()])` por `addresses.toArray(new String[0])` en MercadoPagoService ([src/main/java/um/tesoreria/sender/service/MercadoPagoService.java])
 - Actualizado diagrama de secuencia de envío de recibos con participantes detallados (ReciboController, FacturacionElectronicaClient, JavaMailSender, MimeMessageHelper, ReciboMessageCheckClient) y bloques activate/deactivate ([docs/diagrams/flujo-envio-recibo.mmd])
 
+### Fixed
+- Alineada configuración de test `src/test/resources/bootstrap.yml` con el nuevo esquema `app.mail.fromchequera` / `app.mail.fromrecibo`, reemplazando la propiedad antigua `app.mail.from` ([src/test/resources/bootstrap.yml])
+
 ### Removed
 - Eliminada propiedad `app.mail.from` — reemplazada por `app.mail.fromchequera` y `app.mail.fromrecibo` ([src/main/java/um/tesoreria/sender/service/ChequeraService.java], [src/main/resources/bootstrap.yml])
 

--- a/src/test/resources/bootstrap.yml
+++ b/src/test/resources/bootstrap.yml
@@ -11,7 +11,8 @@ spring:
       group-id: test-group
 app:
   mail:
-    from: envios.chequeras@um.edu.ar
+    fromchequera: fromchequera
+    fromrecibo: fromrecibo
     username: test
     password: test
   testing: true


### PR DESCRIPTION
Closes #105

## Descripción

Se alinea la configuración de test `src/test/resources/bootstrap.yml` con el nuevo esquema `app.mail.fromchequera` / `app.mail.fromrecibo`, reemplazando la propiedad antigua `app.mail.from` que fue eliminada en el release `2.0.0`.

## Cambios Realizados

- **`src/test/resources/bootstrap.yml`**: Reemplazado `app.mail.from: envios.chequeras@um.edu.ar` por:
  - `app.mail.fromchequera: fromchequera`
  - `app.mail.fromrecibo: fromrecibo`
- **`CHANGELOG.md`**: Agregada entrada en sección `Fixed` documentando el cambio.

## Verificación

- [ ] Los tests existentes pasan correctamente con la nueva configuración.
- [ ] Verificar que `mvn test` se ejecute sin errores de configuración de mail.
